### PR TITLE
Allow configuring arithmetic operations in profile

### DIFF
--- a/src/components/profil/component.preact.tsx
+++ b/src/components/profil/component.preact.tsx
@@ -3,12 +3,13 @@ import Button from 'antd/es/button';
 import Col from 'antd/es/grid/col';
 import InputNumber from 'antd/es/input-number';
 import Modal from 'antd/lib/modal/Modal';
+import Checkbox from 'antd/es/checkbox';
 import { h } from 'preact';
 
 import { GenericComponent } from '@leanup/lib/components/generic';
 import { ReactComponent } from '@leanup/lib/components/react';
 
-import { ProfilController } from './controller';
+import { ProfilController, Rechenart } from './controller';
 
 export class ProfilComponent extends ReactComponent<unknown, ProfilController> implements GenericComponent {
   public readonly ctrl: ProfilController = new ProfilController();
@@ -16,7 +17,21 @@ export class ProfilComponent extends ReactComponent<unknown, ProfilController> i
   private timeoutRange: NodeJS.Timeout | undefined;
   private timeoutLimit: NodeJS.Timeout | undefined;
 
+  private getOperationLabel(operation: Rechenart): string {
+    switch (operation) {
+      case 'addition':
+        return 'Addition ( + )';
+      case 'subtraction':
+        return 'Subtraktion ( - )';
+      case 'multiplication':
+        return 'Multiplikation ( × )';
+      default:
+        return operation;
+    }
+  }
+
   render(): JSX.Element {
+    const enabledCount = Object.values(this.ctrl.operations).filter(Boolean).length;
     return (
       <div>
         <Modal
@@ -93,6 +108,37 @@ export class ProfilComponent extends ReactComponent<unknown, ProfilController> i
                   />
                 </Form.Item>
               </Col>
+            </Row>
+          </Card>
+          <br />
+          <Card>
+            <h2>Rechenarten auswählen</h2>
+            <p>Wähle aus, welche Rechenarten verwendet werden sollen.</p>
+            <Row gutter={[0, 16]}>
+              {Object.entries(this.ctrl.operations).map(([operation, isEnabled]) => {
+                const key = operation as Rechenart;
+                return (
+                  <Col key={operation} span={24}>
+                    <Checkbox
+                      checked={isEnabled}
+                      disabled={enabledCount === 1 && isEnabled}
+                      onChange={(event) => {
+                        const saved = this.ctrl.setOperation(key, event.target.checked);
+                        this.forceUpdate();
+                        if (saved) {
+                          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                          message.success('Rechenarten wurden gespeichert.');
+                        } else {
+                          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                          message.warning('Mindestens eine Rechenart muss aktiv bleiben.');
+                        }
+                      }}
+                    >
+                      {this.getOperationLabel(key)}
+                    </Checkbox>
+                  </Col>
+                );
+              })}
             </Row>
           </Card>
           <br />

--- a/src/components/profil/controller.ts
+++ b/src/components/profil/controller.ts
@@ -3,20 +3,27 @@ import { DI } from '@leanup/lib/helpers/injector';
 
 import { StorageService } from '../../services/storage/service';
 
+export type Rechenart = 'addition' | 'subtraction' | 'multiplication';
+
+interface ProfilSettings {
+  maxValue: number;
+  minValue: number;
+  operations: Record<Rechenart, boolean>;
+}
+
 export class ProfilController extends AbstractController {
   private readonly storageService: StorageService = DI.get<StorageService>('StorageService');
   public maxValue: number;
   public minValue: number;
   public dayLimit: number;
+  public operations: Record<Rechenart, boolean>;
 
   public constructor() {
     super();
-    const profil = this.storageService.getItem<{
-      maxValue: number;
-      minValue: number;
-    }>('profil');
+    const profil = this.getProfilSettings();
     this.maxValue = profil.maxValue;
     this.minValue = profil.minValue;
+    this.operations = profil.operations;
 
     const watermarks = this.storageService.getItem<{
       dayLimit: number;
@@ -24,15 +31,65 @@ export class ProfilController extends AbstractController {
     this.dayLimit = watermarks.dayLimit;
   }
 
+  private getProfilSettings(): ProfilSettings {
+    const profil = this.storageService.getItem<{
+      maxValue: number;
+      minValue: number;
+      operations?: Partial<Record<Rechenart, boolean>>;
+    }>('profil');
+
+    const operations: Record<Rechenart, boolean> = {
+      addition: profil.operations?.addition !== false,
+      subtraction: profil.operations?.subtraction !== false,
+      multiplication: profil.operations?.multiplication !== false,
+    };
+
+    if (!operations.addition && !operations.subtraction && !operations.multiplication) {
+      operations.addition = true;
+    }
+
+    return {
+      maxValue: profil.maxValue,
+      minValue: profil.minValue,
+      operations,
+    };
+  }
+
+  private setProfilSettings(settings: Partial<ProfilSettings>): void {
+    this.storageService.setItem('profil', {
+      minValue: this.minValue,
+      maxValue: this.maxValue,
+      operations: this.operations,
+      ...settings,
+    });
+  }
+
   public setRange(minValue: number, maxValue: number): void {
     minValue = Math.floor(minValue);
     maxValue = Math.floor(maxValue);
     if (minValue < maxValue && 0 <= minValue && 20 <= maxValue) {
-      this.storageService.setItem('profil', {
+      this.minValue = minValue;
+      this.maxValue = maxValue;
+      this.setProfilSettings({
         minValue: minValue,
         maxValue: maxValue,
       });
     }
+  }
+
+  public setOperation(operation: Rechenart, enabled: boolean): boolean {
+    const nextOperations: Record<Rechenart, boolean> = {
+      ...this.operations,
+      [operation]: enabled,
+    };
+
+    if (!nextOperations.addition && !nextOperations.subtraction && !nextOperations.multiplication) {
+      return false;
+    }
+
+    this.operations = nextOperations;
+    this.setProfilSettings({ operations: { ...this.operations } });
+    return true;
   }
 
   public setDayLimit(dayLimit: number): void {

--- a/src/services/aufgaben/service.ts
+++ b/src/services/aufgaben/service.ts
@@ -35,7 +35,7 @@ class RechenAufgabeSubtraktion extends RechenAufgabe {
 }
 
 class RechenAufgabeMultiplikation extends RechenAufgabe {
-  public readonly sign = '•';
+  public readonly sign = '×';
   public getErgebnis(): number {
     let result = this.values[0];
     for (let i = 1; i < this.values.length; i++) {
@@ -43,6 +43,15 @@ class RechenAufgabeMultiplikation extends RechenAufgabe {
     }
     return result;
   }
+}
+
+type RechenAufgabeKonstruktor = new (values: number[]) => RechenAufgabe;
+type OperationKey = 'addition' | 'subtraction' | 'multiplication';
+
+interface ProfilSettings {
+  maxValue: number;
+  minValue: number;
+  operations: Record<OperationKey, boolean>;
 }
 
 export class AufgabenService {
@@ -71,6 +80,8 @@ export class AufgabenService {
             this.aufgabe = new RechenAufgabeSubtraktion(storedAufgabe.values);
             break;
           case '*':
+          case '×':
+          case '•':
             this.aufgabe = new RechenAufgabeMultiplikation(storedAufgabe.values);
             break;
           default:
@@ -88,38 +99,58 @@ export class AufgabenService {
     return Math.floor(Math.random() * Math.floor(max + 1));
   }
 
-  private getProfil(): {
-    maxValue: number;
-    minValue: number;
-  } {
-    return this.storageService.getItem<{
+  private getProfil(): ProfilSettings {
+    const profil = this.storageService.getItem<{
       maxValue: number;
       minValue: number;
+      operations?: Partial<Record<OperationKey, boolean>>;
     }>('profil');
+
+    const operations: Record<OperationKey, boolean> = {
+      addition: profil.operations?.addition !== false,
+      subtraction: profil.operations?.subtraction !== false,
+      multiplication: profil.operations?.multiplication !== false,
+    };
+
+    if (!operations.addition && !operations.subtraction && !operations.multiplication) {
+      operations.addition = true;
+    }
+
+    return {
+      maxValue: profil.maxValue,
+      minValue: profil.minValue,
+      operations,
+    };
   }
 
-  private patchAufgabe(rechenAufgabe: any): RechenAufgabe {
-    const profil = this.getProfil();
+  private patchAufgabe(
+    RechenAufgabeClass: RechenAufgabeKonstruktor,
+    profil: ProfilSettings
+  ): RechenAufgabe {
     let aufgabe: RechenAufgabe;
     do {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-call
-      aufgabe = new rechenAufgabe([this.getRandomInt(profil.maxValue), this.getRandomInt(profil.maxValue)]);
+      aufgabe = new RechenAufgabeClass([
+        this.getRandomInt(profil.maxValue),
+        this.getRandomInt(profil.maxValue),
+      ]);
     } while (aufgabe.getErgebnis() < profil.minValue || aufgabe.getErgebnis() > profil.maxValue);
     return aufgabe;
   }
 
   private newAufgabe(): RechenAufgabe {
-    let aufgabe: RechenAufgabe;
-    switch (this.getRandomInt(2)) {
-      case 0:
-        aufgabe = this.patchAufgabe(RechenAufgabeAddition);
-        break;
-      case 1:
-        aufgabe = this.patchAufgabe(RechenAufgabeSubtraktion);
-        break;
-      default:
-        aufgabe = this.patchAufgabe(RechenAufgabeMultiplikation);
-    }
+    const profil = this.getProfil();
+    const constructors: Record<OperationKey, RechenAufgabeKonstruktor> = {
+      addition: RechenAufgabeAddition,
+      subtraction: RechenAufgabeSubtraktion,
+      multiplication: RechenAufgabeMultiplikation,
+    };
+    const enabledConstructors = (Object.keys(profil.operations) as OperationKey[])
+      .filter((key) => profil.operations[key])
+      .map((key) => constructors[key]);
+
+    const randomIndex = this.getRandomInt(enabledConstructors.length - 1);
+    const SelectedConstructor = enabledConstructors[randomIndex];
+    const aufgabe = this.patchAufgabe(SelectedConstructor, profil);
     this.storageService.setItem('aufgabe', {
       answer: null,
       sign: aufgabe.sign,

--- a/src/services/storage/mock.json
+++ b/src/services/storage/mock.json
@@ -1,7 +1,12 @@
 {
   "profil": {
     "minValue": 0,
-    "maxValue": 20
+    "maxValue": 20,
+    "operations": {
+      "addition": true,
+      "subtraction": true,
+      "multiplication": true
+    }
   },
   "results": [],
   "watermarks": {


### PR DESCRIPTION
## Summary
- add checkboxes in the profile to choose which arithmetic operations are enabled while preventing the last one from being deselected
- persist the selected operations in the stored profile data and use them when generating new exercises
- extend the default storage mock with operation flags and keep backward compatibility for existing stored tasks

## Testing
- npm test *(fails: TypeError: Function.prototype.apply was called on undefined, Node.js v22.19.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d8b3b80794832ba2778e2aa76b9515