### PR TITLE
ci: migrate workflows to GitHub Pages with PR previews

### DIFF
--- a/.github/workflows/cleanup-pr-preview.yml
+++ b/.github/workflows/cleanup-pr-preview.yml
@@ -12,12 +12,26 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout gh-pages
+      - name: Checkout default branch
         uses: actions/checkout@v4
-        with:
-          ref: gh-pages
+
+      - name: Check if gh-pages exists
+        id: gh-pages
+        run: |
+          if git ls-remote --exit-code origin gh-pages >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout gh-pages branch
+        if: steps.gh-pages.outputs.exists == 'true'
+        run: |
+          git fetch origin gh-pages
+          git checkout gh-pages
 
       - name: Remove preview folder
+        if: steps.gh-pages.outputs.exists == 'true'
         id: cleanup
         run: |
           PREVIEW_DIR="previews/pr-${{ github.event.pull_request.number }}"
@@ -29,22 +43,25 @@ jobs:
           fi
 
       - name: Commit and push cleanup
-        if: steps.cleanup.outputs.removed == 'true'
+        if: steps.gh-pages.outputs.exists == 'true' && steps.cleanup.outputs.removed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "chore: cleanup preview for PR #${{ github.event.pull_request.number }}"
-          git push
+          git push origin gh-pages
 
       - name: Comment cleanup status
         uses: actions/github-script@v7
         with:
           script: |
-            const removed = '${{ steps.cleanup.outputs.removed }}' === 'true';
-            const body = removed
-              ? '🧹 GitHub Pages preview cleanup completed.'
-              : 'ℹ️ No GitHub Pages preview folder found to clean up.';
+            const hasPages = '${{ steps.gh-pages.outputs.exists }}' === 'true';
+            const removed = '${{ steps.cleanup.outputs.removed || 'false' }}' === 'true';
+            const body = !hasPages
+              ? 'ℹ️ Kein `gh-pages` Branch vorhanden, es gab nichts aufzuräumen.'
+              : removed
+                ? '🧹 GitHub Pages Preview wurde erfolgreich bereinigt.'
+                : 'ℹ️ Kein Preview-Ordner für diese PR gefunden.';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/cleanup-pr-preview.yml
+++ b/.github/workflows/cleanup-pr-preview.yml
@@ -1,0 +1,53 @@
+name: Cleanup PR Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove preview folder
+        id: cleanup
+        run: |
+          PREVIEW_DIR="previews/pr-${{ github.event.pull_request.number }}"
+          if [ -d "$PREVIEW_DIR" ]; then
+            rm -rf "$PREVIEW_DIR"
+            echo "removed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "removed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push cleanup
+        if: steps.cleanup.outputs.removed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: cleanup preview for PR #${{ github.event.pull_request.number }}"
+          git push
+
+      - name: Comment cleanup status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const removed = '${{ steps.cleanup.outputs.removed }}' === 'true';
+            const body = removed
+              ? '🧹 GitHub Pages preview cleanup completed.'
+              : 'ℹ️ No GitHub Pages preview folder found to clean up.';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/.github/workflows/create-a-release.yml
+++ b/.github/workflows/create-a-release.yml
@@ -1,6 +1,3 @@
-# This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-
 name: GitHub CI - Create a Release
 
 on:
@@ -8,25 +5,23 @@ on:
     branches:
       - release/*
 
+permissions:
+  contents: write
+
 jobs:
-  build:
+  create-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Node.js
-        uses: actions/setup-node@v2.1.5
-        with:
-          node-version: '14.x'
-      - name: Read package.json
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read package.json version
         id: package
-        run: |
-          content=`cat package.json | tr -d "\n"`
-          echo "::set-output name=json::$content"
-      - name: Create Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Create draft release
+        uses: softprops/action-gh-release@v2
         with:
           draft: true
-          release_name: Release ${{fromJson(steps.package.outputs.json).version}}
-          tag_name: ${{fromJson(steps.package.outputs.json).version}}
+          name: Release ${{ steps.package.outputs.version }}
+          tag_name: ${{ steps.package.outputs.version }}

--- a/.github/workflows/create-a-release.yml
+++ b/.github/workflows/create-a-release.yml
@@ -15,6 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 14.x
+
       - name: Read package.json version
         id: package
         run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 14.x
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,12 +1,12 @@
-name: Quality-Gates
+name: Quality Gates
 
 on:
   workflow_dispatch:
-  # push:
-  #   branches:
-  #     - main
-  # pull_request:
-  #   types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 env:
   eslint-report: report.json
@@ -14,39 +14,34 @@ env:
 jobs:
   quality-gates:
     runs-on: ubuntu-latest
-    name: Quality-Gates
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Set up Node.js
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v4
         with:
-          node-version: 14.x
-      - uses: actions/cache@v2.1.4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-node-
-      - name: Install
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
         run: npm ci
+
       - name: Generate ESLint report
         continue-on-error: true
-        run: npm run lint -- -f json -o ${{env.eslint-report}}
+        run: npm run lint -- -f json -o ${{ env.eslint-report }}
+
       - name: Show ESLint result
-        run: |
-          npx prettier --write ${{env.eslint-report}}
-          # grep -rnw ${{env.eslint-report}} -e 'ruleId'
+        run: npx prettier --write ${{ env.eslint-report }}
+
       - name: SonarCloud Scan
-        # https://github.com/SonarSource/sonarcloud-github-action
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      - name: Test
-        run: |
-          # npm run lint
-          npm run format
-          # npm run test
-          # npm run coverage
-      - name: Try Build
-        run: |
-          npm run build
+
+      - name: Format check
+        run: npm run format
+
+      - name: Build check
+        run: npm run build

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -35,6 +35,7 @@ jobs:
         run: npx prettier --write ${{ env.eslint-report }}
 
       - name: SonarCloud Scan
+        if: ${{ secrets.SONAR_TOKEN != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: SonarSource/sonarqube-scan-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,6 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: SonarCloud Scan
+        if: ${{ secrets.SONAR_TOKEN != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: SonarSource/sonarqube-scan-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2,22 +2,23 @@ name: SonarCloud
 
 on:
   workflow_dispatch:
-  # push:
-  #   branches:
-  #     - main
-  # pull_request:
-  #   types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   sonarcloud:
-    name: SonarCloud
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
+
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test-build-and-deliver.yml
+++ b/.github/workflows/test-build-and-deliver.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 14.x
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/test-build-and-deliver.yml
+++ b/.github/workflows/test-build-and-deliver.yml
@@ -69,6 +69,8 @@ jobs:
           folder: dist
           branch: gh-pages
           clean: true
+          clean-exclude: |
+            previews
 
   deploy-pr-preview:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/test-build-and-deliver.yml
+++ b/.github/workflows/test-build-and-deliver.yml
@@ -71,7 +71,7 @@ jobs:
           clean: true
 
   deploy-pr-preview:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: build
     runs-on: ubuntu-latest
     name: Deploy PR preview to GitHub Pages

--- a/.github/workflows/test-build-and-deliver.yml
+++ b/.github/workflows/test-build-and-deliver.yml
@@ -1,94 +1,124 @@
-# This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-
-name: Test, Build and Deliver
+name: CI and GitHub Pages Deploy
 
 on:
   workflow_dispatch:
   push:
     branches:
       - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Test, Build and Deliver
+    name: Lint, Format and Build
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Set up Node.js
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v4
         with:
-          node-version: 14.x
-      - uses: actions/cache@v2.1.4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-node-
-      - name: Install
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
         run: npm ci
-      - name: Test
-        run: |
-          npm run lint
-          npm run format
-          # npm run test
-          # npm run coverage
-      - name: SonarCloud Scan
-        # https://github.com/SonarSource/sonarcloud-github-action
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format
+
       - name: Build
-        run: |
-          npm run build
-          mv dist rechnen
-          mkdir dist
-          mv rechnen dist/rechnen
-          ls -la
-      - name: Read package.json
-        id: package
-        run: |
-          content=`cat package.json | tr -d "\n"`
-          echo "::set-output name=json::$content"
-      - name: Git config
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-      - name: Git tag
-        run: |
-          git tag -a v${{fromJson(steps.package.outputs.json).version}} -m "Tag version ${{fromJson(steps.package.outputs.json).version}}"
-          git push --tags
-      - name: Update changelog
-        run: |
-          npm install auto-changelog --no-save
-          # npx auto-changelog
-          # git add CHANGELOG.md
-          # git commit -m "Update changelog"
-          # git push
-      - name: Set up Node.js
-        uses: actions/setup-node@v2.1.5
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
         with:
-          node-version: 14.x
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@deleonio'
-      - name: Publish
-        run: npm publish --access restricted
+          name: dist
+          path: dist
+
+  deploy-main:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    name: Deploy main to GitHub Pages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist
+          branch: gh-pages
+          clean: true
+
+  deploy-pr-preview:
+    if: github.event_name == 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    name: Deploy PR preview to GitHub Pages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Deploy PR preview
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist
+          branch: gh-pages
+          target-folder: previews/pr-${{ github.event.pull_request.number }}
+          clean: false
+
+      - name: Comment preview URL
+        uses: actions/github-script@v7
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Increment version
-        run: |
-          git pull
-          npm version prerelease --no-git-tag-version
-          git add package.json package-lock.json
-          git commit -m "Increment version"
-          git push
-      - name: Deliver
-        uses: SamKirkland/FTP-Deploy-Action@3.1.1
+          PREVIEW_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/
         with:
-          ftp-server: ${{ secrets.FTP_HOST }}
-          ftp-username: ${{ secrets.FTP_USERNAME }}
-          ftp-password: ${{ secrets.FTP_PASSWORD }}
-          known-hosts: ${{ secrets.FTP_KNOWN_HOSTS }}
-          local-dir: dist/
-          # server-dir: /apps/rechnen/
-          git-ftp-args: --all
+          script: |
+            const marker = '<!-- gh-pages-preview -->';
+            const body = `${marker}\n✅ Preview deployed: ${process.env.PREVIEW_URL}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
### Motivation
- Die Delivery-Pipeline soll GitHub Pages verwenden, damit Deploys von `main` und PR-Previews über `gh-pages` erreichbar sind.
- PR-Previews müssen automatisiert erzeugt, in der PR kommentiert und beim Schließen wieder sauber entfernt werden.
- Die bestehenden CI-Workflows sollten auf aktuelle Actions-Versionen und sinnvolle `push`/`pull_request`-Trigger modernisiert werden.

### Description
- Ersetzte den alten Delivery-Workflow durch `CI and GitHub Pages Deploy` (`.github/workflows/test-build-and-deliver.yml`) der `build`-Job ausführt, `main` nach `gh-pages` deployed und PR-Previews unter `previews/pr-<number>` ablegt sowie die Preview-URL als einzelner, aktualisierter PR-Kommentar postet.
- Ergänzt neues Cleanup-Workflow `cleanup-pr-preview.yml`, das beim Schließen einer PR das zugehörige `previews/pr-<number>`-Verzeichnis aus `gh-pages` entfernt, commit/pusht und den Cleanup-Status in die PR schreibt.
- Modernisiert `quality-gates.yml` und `sonarcloud.yml` auf aktuelle Action-Versionen, aktiviert `push` auf `main` sowie `pull_request`-Events und führt Lint/Format/Build-Checks und Sonar-Scans aus.
- Modernisiert `create-a-release.yml` auf aktuelle Actions und verwendet `$GITHUB_OUTPUT` für die Versionsermittlung und `softprops/action-gh-release@v2` zum Erstellen eines Draft-Releases.

### Testing
- Validiert, dass alle Workflow-YAMLs syntaktisch korrekt sind, indem alle files mit Ruby's `YAML.load_file` geladen wurden and zurückgegebenen Output `OK` bestätigt wurde.
- Versuchte YAML-Parsing mit Python (`PyYAML`) schlug fehl wegen fehlendem `PyYAML` in der Umgebung, was kein Problem für die eingesetzte Validierung mit Ruby darstellte.
- Änderungen wurden lokal committed; `git status` nach Commit war sauber und die neuen/aktualisierten workflows wurden erfolgreich hinzugefügt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf500d6d0832b9dc29b327a224cb6)