### PR TITLE
fix: require explicit profile selection before accessing settings

### DIFF
--- a/src/services/storage/mock.json
+++ b/src/services/storage/mock.json
@@ -1,13 +1,4 @@
 {
-  "profil": {
-    "minValue": 0,
-    "maxValue": 20,
-    "operators": ["+", "-", "•", ":"],
-    "difficultyMin": 1,
-    "difficultyMax": 1
-  },
-  "results": [],
-  "watermarks": {
-    "dayLimit": 10
-  }
+  "activeProfileId": null,
+  "profiles": {}
 }


### PR DESCRIPTION
Update mock.json to the new profile store format with no active profile and no pre-created profiles. Previously, the legacy mock format caused StorageService to auto-create an active profile on first load, allowing access to profile settings without the user ever selecting a profile.

Now hasActiveProfile() returns false until the user explicitly creates or selects a profile on the start screen, as the route guard intends. Settings remain per-profile as the storage architecture already ensures.

https://claude.ai/code/session_01W5M25wJWpwkPDAfmqU1r3M