### PR TITLE
feat: Vokabeltrainer mit profilbasierter Wortliste

### DIFF
--- a/src/components/app/component.preact.tsx
+++ b/src/components/app/component.preact.tsx
@@ -14,6 +14,7 @@ import { InfoComponent } from '../info/component.preact';
 import { ProfilComponent } from '../profil/component.preact';
 import { RechnenComponent } from '../rechnen/component.preact';
 import { StartComponent } from '../start/component.preact';
+import { VokabelnComponent } from '../vokabeln/component.preact';
 import { AppController } from './controller';
 
 const APP_METADATE = {
@@ -50,15 +51,20 @@ export class AppComponent extends ReactComponent<unknown, AppController> impleme
 						)}
 						{hasActiveProfile && (
 							<Menu.Item key="2">
-								<a href="#history">Verlauf</a>
+								<a href="#vokabeln">Vokabeln</a>
 							</Menu.Item>
 						)}
 						{hasActiveProfile && (
 							<Menu.Item key="3">
+								<a href="#history">Verlauf</a>
+							</Menu.Item>
+						)}
+						{hasActiveProfile && (
+							<Menu.Item key="4">
 								<a href="#profil">Profil</a>
 							</Menu.Item>
 						)}
-						<Menu.Item key="4">
+						<Menu.Item key="5">
 							<a href="#info">Info</a>
 						</Menu.Item>
 					</Menu>
@@ -71,6 +77,9 @@ export class AppComponent extends ReactComponent<unknown, AppController> impleme
 							</Route>
 							<Route exact path="/">
 								{hasActiveProfile ? <RechnenComponent /> : <StartComponent />}
+							</Route>
+							<Route exact path="/vokabeln">
+								{hasActiveProfile ? <VokabelnComponent /> : <StartComponent />}
 							</Route>
 							<Route exact path="/history">
 								{hasActiveProfile ? <HistoryComponent /> : <StartComponent />}

--- a/src/components/profil/component.preact.tsx
+++ b/src/components/profil/component.preact.tsx
@@ -2,6 +2,7 @@ import { Card, Form, message, Row } from 'antd';
 import Button from 'antd/es/button';
 import Checkbox from 'antd/es/checkbox';
 import Col from 'antd/es/grid/col';
+import Input from 'antd/es/input';
 import InputNumber from 'antd/es/input-number';
 import Slider from 'antd/es/slider';
 import Modal from 'antd/lib/modal/Modal';
@@ -46,6 +47,7 @@ export class ProfilComponent extends ReactComponent<unknown, ProfilController> i
 						dayLimit: this.ctrl.dayLimit,
 						operators: this.ctrl.operators,
 						difficulty: this.ctrl.difficultyMin,
+						vocabularyList: this.ctrl.vocabularyRawText,
 					}}
 					noValidate={true}
 				>
@@ -166,6 +168,27 @@ export class ProfilComponent extends ReactComponent<unknown, ProfilController> i
 											}
 											this.forceUpdate();
 										}}
+									/>
+								</Form.Item>
+							</Col>
+						</Row>
+					</Card>
+					<br />
+
+					<Card>
+						<h2>Vokabelliste</h2>
+						<p>Hinterlege hier Deine Vokabeln im Format <b>Frage;Antwort</b> (eine Zeile pro Eintrag).</p>
+						<Row>
+							<Col style={{ width: '100%' }}>
+								<Form.Item label="Wortliste" name="vocabularyList">
+									<Input.TextArea
+										autoSize={{ minRows: 6, maxRows: 12 }}
+										onChange={(event) => {
+											this.ctrl.setVocabularyRawText(event.currentTarget.value);
+											message.success('Vokabelliste wurde gespeichert.');
+											this.forceUpdate();
+										}}
+										placeholder={'hallo;hello\nKatze;cat'}
 									/>
 								</Form.Item>
 							</Col>

--- a/src/components/profil/component.preact.tsx
+++ b/src/components/profil/component.preact.tsx
@@ -177,7 +177,9 @@ export class ProfilComponent extends ReactComponent<unknown, ProfilController> i
 
 					<Card>
 						<h2>Vokabelliste</h2>
-						<p>Hinterlege hier Deine Vokabeln im Format <b>Frage;Antwort</b> (eine Zeile pro Eintrag).</p>
+						<p>
+							Hinterlege hier Deine Vokabeln im Format <b>Frage;Antwort</b> (eine Zeile pro Eintrag).
+						</p>
 						<Row>
 							<Col style={{ width: '100%' }}>
 								<Form.Item label="Wortliste" name="vocabularyList">

--- a/src/components/profil/controller.ts
+++ b/src/components/profil/controller.ts
@@ -12,6 +12,7 @@ export class ProfilController extends AbstractController {
 	public operators: string[];
 	public difficultyMin: number;
 	public difficultyMax: number;
+	public vocabularyRawText: string;
 
 	public constructor() {
 		super();
@@ -22,6 +23,7 @@ export class ProfilController extends AbstractController {
 			difficultyLevel?: number;
 			difficultyMin?: number;
 			difficultyMax?: number;
+			vocabularyList?: { question: string; answer: string }[];
 		}>('profil');
 		this.maxValue = profil.maxValue;
 		this.minValue = profil.minValue;
@@ -39,6 +41,7 @@ export class ProfilController extends AbstractController {
 		if (this.difficultyMin > this.difficultyMax) {
 			this.difficultyMax = this.difficultyMin;
 		}
+		this.vocabularyRawText = (profil.vocabularyList || []).map((entry) => `${entry.question};${entry.answer}`).join('\n');
 
 		const watermarks = this.storageService.getItem<{
 			dayLimit: number;
@@ -58,6 +61,7 @@ export class ProfilController extends AbstractController {
 				operators: this.operators,
 				difficultyMin: this.difficultyMin,
 				difficultyMax: this.difficultyMax,
+				vocabularyList: this.getVocabularyList(),
 			});
 		}
 	}
@@ -74,6 +78,7 @@ export class ProfilController extends AbstractController {
 			operators: this.operators,
 			difficultyMin: this.difficultyMin,
 			difficultyMax: this.difficultyMax,
+			vocabularyList: this.getVocabularyList(),
 		});
 		return true;
 	}
@@ -92,6 +97,7 @@ export class ProfilController extends AbstractController {
 			operators: this.operators,
 			difficultyMin: this.difficultyMin,
 			difficultyMax: this.difficultyMax,
+			vocabularyList: this.getVocabularyList(),
 		});
 	}
 
@@ -106,6 +112,46 @@ export class ProfilController extends AbstractController {
 				dayLimit: dayLimit,
 			});
 		}
+	}
+
+	private getVocabularyList(): { question: string; answer: string }[] {
+		return this.vocabularyRawText
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0)
+			.map((line) => {
+				const [question, ...answerParts] = line.split(';');
+				return {
+					question: (question || '').trim(),
+					answer: answerParts.join(';').trim(),
+				};
+			})
+			.filter((entry) => entry.question.length > 0 && entry.answer.length > 0);
+	}
+
+	public setVocabularyRawText(vocabularyRawText: string): void {
+		this.vocabularyRawText = vocabularyRawText;
+		const vocabularyList = vocabularyRawText
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0)
+			.map((line) => {
+				const [question, ...answerParts] = line.split(';');
+				return {
+					question: (question || '').trim(),
+					answer: answerParts.join(';').trim(),
+				};
+			})
+			.filter((entry) => entry.question.length > 0 && entry.answer.length > 0);
+
+		this.storageService.setItem('profil', {
+			minValue: this.minValue,
+			maxValue: this.maxValue,
+			operators: this.operators,
+			difficultyMin: this.difficultyMin,
+			difficultyMax: this.difficultyMax,
+			vocabularyList: vocabularyList,
+		});
 	}
 
 	public deleteProfile(): void {

--- a/src/components/vokabeln/component.preact.tsx
+++ b/src/components/vokabeln/component.preact.tsx
@@ -29,54 +29,51 @@ export class VokabelnComponent extends ReactComponent<unknown, VokabelnControlle
 				<h1>Vokabeln trainieren</h1>
 				{!currentEntry && (
 					<Card>
-						<Empty
-							description="Noch keine Vokabeln hinterlegt. Bitte im Profil eine Wortliste speichern."
-							image={Empty.PRESENTED_IMAGE_SIMPLE}
-						/>
+						<Empty description="Noch keine Vokabeln hinterlegt. Bitte im Profil eine Wortliste speichern." image={Empty.PRESENTED_IMAGE_SIMPLE} />
 					</Card>
 				)}
-					{currentEntry && (
-						<Card bodyStyle={{ padding: '16px 16px 20px 16px' }}>
-							<Space direction="vertical" size="large" style={{ width: '100%', textAlign: 'center' }}>
-								<Tag color="blue" style={{ alignSelf: 'center', fontSize: '14px', padding: '6px 12px' }}>
-									{current} / {total}
-								</Tag>
-								<Title level={4} style={{ marginBottom: 0 }}>
-									Übersetze
-								</Title>
-								<Text strong style={{ fontSize: '32px', lineHeight: 1.2, display: 'block', minHeight: '72px' }}>
-									{prompt}
-								</Text>
-								{this.showAnswer && (
-									<>
-										<Title level={5} style={{ marginBottom: 0 }}>
-											Antwort
-										</Title>
-										<Text style={{ fontSize: '28px', lineHeight: 1.2, display: 'block', minHeight: '64px' }}>{solution}</Text>
-									</>
-								)}
-								<Button
-									type="primary"
-									size="large"
-									block
-									style={{ height: '56px', fontSize: '20px', fontWeight: 'bold' }}
-									onClick={() => {
-										if (this.showAnswer) {
-											this.showAnswer = false;
-											this.ctrl.nextEntry();
-											this.randomizeDirection();
-										} else {
-											this.showAnswer = true;
-											message.info('Antwort eingeblendet.');
-										}
-										this.forceUpdate();
-									}}
-								>
-									{this.showAnswer ? 'Nächste Vokabel' : 'Antwort anzeigen'}
-								</Button>
-							</Space>
-						</Card>
-					)}
+				{currentEntry && (
+					<Card bodyStyle={{ padding: '16px 16px 20px 16px' }}>
+						<Space direction="vertical" size="large" style={{ width: '100%', textAlign: 'center' }}>
+							<Tag color="blue" style={{ alignSelf: 'center', fontSize: '14px', padding: '6px 12px' }}>
+								{current} / {total}
+							</Tag>
+							<Title level={4} style={{ marginBottom: 0 }}>
+								Übersetze
+							</Title>
+							<Text strong style={{ fontSize: '32px', lineHeight: 1.2, display: 'block', minHeight: '72px' }}>
+								{prompt}
+							</Text>
+							{this.showAnswer && (
+								<>
+									<Title level={5} style={{ marginBottom: 0 }}>
+										Antwort
+									</Title>
+									<Text style={{ fontSize: '28px', lineHeight: 1.2, display: 'block', minHeight: '64px' }}>{solution}</Text>
+								</>
+							)}
+							<Button
+								type="primary"
+								size="large"
+								block
+								style={{ height: '56px', fontSize: '20px', fontWeight: 'bold' }}
+								onClick={() => {
+									if (this.showAnswer) {
+										this.showAnswer = false;
+										this.ctrl.nextEntry();
+										this.randomizeDirection();
+									} else {
+										this.showAnswer = true;
+										message.info('Antwort eingeblendet.');
+									}
+									this.forceUpdate();
+								}}
+							>
+								{this.showAnswer ? 'Nächste Vokabel' : 'Antwort anzeigen'}
+							</Button>
+						</Space>
+					</Card>
+				)}
 			</div>
 		);
 	}

--- a/src/components/vokabeln/component.preact.tsx
+++ b/src/components/vokabeln/component.preact.tsx
@@ -33,9 +33,9 @@ export class VokabelnComponent extends ReactComponent<unknown, VokabelnControlle
 						/>
 					</Card>
 				)}
-				{currentEntry && (
-					<Card>
-						<Space direction="vertical" size="middle" style={{ width: '100%' }}>
+					{currentEntry && (
+						<Card>
+							<Space direction="vertical" size="middle" style={{ width: '100%' }}>
 							<Title level={4}>Übersetze</Title>
 							<Text strong>{prompt}</Text>
 							{this.showAnswer && (
@@ -44,33 +44,25 @@ export class VokabelnComponent extends ReactComponent<unknown, VokabelnControlle
 									<Text>{solution}</Text>
 								</>
 							)}
-							<Space>
 								<Button
 									type="primary"
 									onClick={() => {
-										this.showAnswer = !this.showAnswer;
 										if (this.showAnswer) {
+											this.showAnswer = false;
+											this.ctrl.nextEntry();
+											this.randomizeDirection();
+										} else {
+											this.showAnswer = true;
 											message.info('Antwort eingeblendet.');
 										}
 										this.forceUpdate();
 									}}
 								>
-									{this.showAnswer ? 'Antwort ausblenden' : 'Antwort anzeigen'}
-								</Button>
-								<Button
-									onClick={() => {
-										this.showAnswer = false;
-										this.ctrl.nextEntry();
-										this.randomizeDirection();
-										this.forceUpdate();
-									}}
-								>
-									Nächste Vokabel
+									{this.showAnswer ? 'Nächste Vokabel' : 'Antwort anzeigen'}
 								</Button>
 							</Space>
-						</Space>
-					</Card>
-				)}
+						</Card>
+					)}
 			</div>
 		);
 	}

--- a/src/components/vokabeln/component.preact.tsx
+++ b/src/components/vokabeln/component.preact.tsx
@@ -12,9 +12,16 @@ const { Text, Title } = Typography;
 export class VokabelnComponent extends ReactComponent<unknown, VokabelnController> implements GenericComponent {
 	public readonly ctrl: VokabelnController = new VokabelnController();
 	private showAnswer = false;
+	private isReverseDirection = Math.random() >= 0.5;
+
+	private randomizeDirection(): void {
+		this.isReverseDirection = Math.random() >= 0.5;
+	}
 
 	public render(): JSX.Element {
 		const currentEntry = this.ctrl.getCurrentEntry();
+		const prompt = this.isReverseDirection ? currentEntry?.answer : currentEntry?.question;
+		const solution = this.isReverseDirection ? currentEntry?.question : currentEntry?.answer;
 		return (
 			<div>
 				<h1>Vokabeln trainieren</h1>
@@ -29,12 +36,12 @@ export class VokabelnComponent extends ReactComponent<unknown, VokabelnControlle
 				{currentEntry && (
 					<Card>
 						<Space direction="vertical" size="middle" style={{ width: '100%' }}>
-							<Title level={4}>Frage</Title>
-							<Text strong>{currentEntry.question}</Text>
+							<Title level={4}>Übersetze</Title>
+							<Text strong>{prompt}</Text>
 							{this.showAnswer && (
 								<>
 									<Title level={5}>Antwort</Title>
-									<Text>{currentEntry.answer}</Text>
+									<Text>{solution}</Text>
 								</>
 							)}
 							<Space>
@@ -54,6 +61,7 @@ export class VokabelnComponent extends ReactComponent<unknown, VokabelnControlle
 									onClick={() => {
 										this.showAnswer = false;
 										this.ctrl.nextEntry();
+										this.randomizeDirection();
 										this.forceUpdate();
 									}}
 								>

--- a/src/components/vokabeln/component.preact.tsx
+++ b/src/components/vokabeln/component.preact.tsx
@@ -1,4 +1,4 @@
-import { Card, Empty, message, Space, Typography } from 'antd';
+import { Card, Empty, message, Space, Tag, Typography } from 'antd';
 import Button from 'antd/es/button';
 import { JSX } from 'preact';
 
@@ -22,6 +22,8 @@ export class VokabelnComponent extends ReactComponent<unknown, VokabelnControlle
 		const currentEntry = this.ctrl.getCurrentEntry();
 		const prompt = this.isReverseDirection ? currentEntry?.answer : currentEntry?.question;
 		const solution = this.isReverseDirection ? currentEntry?.question : currentEntry?.answer;
+		const total = this.ctrl.entries.length;
+		const current = total === 0 ? 0 : this.ctrl.currentPosition + 1;
 		return (
 			<div>
 				<h1>Vokabeln trainieren</h1>
@@ -34,18 +36,30 @@ export class VokabelnComponent extends ReactComponent<unknown, VokabelnControlle
 					</Card>
 				)}
 					{currentEntry && (
-						<Card>
-							<Space direction="vertical" size="middle" style={{ width: '100%' }}>
-							<Title level={4}>Übersetze</Title>
-							<Text strong>{prompt}</Text>
-							{this.showAnswer && (
-								<>
-									<Title level={5}>Antwort</Title>
-									<Text>{solution}</Text>
-								</>
-							)}
+						<Card bodyStyle={{ padding: '16px 16px 20px 16px' }}>
+							<Space direction="vertical" size="large" style={{ width: '100%', textAlign: 'center' }}>
+								<Tag color="blue" style={{ alignSelf: 'center', fontSize: '14px', padding: '6px 12px' }}>
+									{current} / {total}
+								</Tag>
+								<Title level={4} style={{ marginBottom: 0 }}>
+									Übersetze
+								</Title>
+								<Text strong style={{ fontSize: '32px', lineHeight: 1.2, display: 'block', minHeight: '72px' }}>
+									{prompt}
+								</Text>
+								{this.showAnswer && (
+									<>
+										<Title level={5} style={{ marginBottom: 0 }}>
+											Antwort
+										</Title>
+										<Text style={{ fontSize: '28px', lineHeight: 1.2, display: 'block', minHeight: '64px' }}>{solution}</Text>
+									</>
+								)}
 								<Button
 									type="primary"
+									size="large"
+									block
+									style={{ height: '56px', fontSize: '20px', fontWeight: 'bold' }}
 									onClick={() => {
 										if (this.showAnswer) {
 											this.showAnswer = false;

--- a/src/components/vokabeln/component.preact.tsx
+++ b/src/components/vokabeln/component.preact.tsx
@@ -1,0 +1,69 @@
+import { Card, Empty, message, Space, Typography } from 'antd';
+import Button from 'antd/es/button';
+import { JSX } from 'preact';
+
+import { GenericComponent } from '@leanup/lib/components/generic';
+import { ReactComponent } from '@leanup/lib/components/react';
+
+import { VokabelnController } from './controller';
+
+const { Text, Title } = Typography;
+
+export class VokabelnComponent extends ReactComponent<unknown, VokabelnController> implements GenericComponent {
+	public readonly ctrl: VokabelnController = new VokabelnController();
+	private showAnswer = false;
+
+	public render(): JSX.Element {
+		const currentEntry = this.ctrl.getCurrentEntry();
+		return (
+			<div>
+				<h1>Vokabeln trainieren</h1>
+				{!currentEntry && (
+					<Card>
+						<Empty
+							description="Noch keine Vokabeln hinterlegt. Bitte im Profil eine Wortliste speichern."
+							image={Empty.PRESENTED_IMAGE_SIMPLE}
+						/>
+					</Card>
+				)}
+				{currentEntry && (
+					<Card>
+						<Space direction="vertical" size="middle" style={{ width: '100%' }}>
+							<Title level={4}>Frage</Title>
+							<Text strong>{currentEntry.question}</Text>
+							{this.showAnswer && (
+								<>
+									<Title level={5}>Antwort</Title>
+									<Text>{currentEntry.answer}</Text>
+								</>
+							)}
+							<Space>
+								<Button
+									type="primary"
+									onClick={() => {
+										this.showAnswer = !this.showAnswer;
+										if (this.showAnswer) {
+											message.info('Antwort eingeblendet.');
+										}
+										this.forceUpdate();
+									}}
+								>
+									{this.showAnswer ? 'Antwort ausblenden' : 'Antwort anzeigen'}
+								</Button>
+								<Button
+									onClick={() => {
+										this.showAnswer = false;
+										this.ctrl.nextEntry();
+										this.forceUpdate();
+									}}
+								>
+									Nächste Vokabel
+								</Button>
+							</Space>
+						</Space>
+					</Card>
+				)}
+			</div>
+		);
+	}
+}

--- a/src/components/vokabeln/controller.ts
+++ b/src/components/vokabeln/controller.ts
@@ -1,0 +1,47 @@
+import { AbstractController } from '@leanup/lib/components/generic';
+import { DI } from '@leanup/lib/helpers/injector';
+
+import { StorageService } from '../../services/storage/service';
+
+export interface VocabularyEntry {
+	question: string;
+	answer: string;
+}
+
+export class VokabelnController extends AbstractController {
+	private readonly storageService: StorageService = DI.get<StorageService>('StorageService');
+	public entries: VocabularyEntry[];
+	public currentIndex = 0;
+
+	public constructor() {
+		super();
+		this.entries = this.getEntries();
+	}
+
+	private getEntries(): VocabularyEntry[] {
+		const profil = this.storageService.getItem<{ vocabularyList?: VocabularyEntry[] }>('profil');
+		const vocabularyList = Array.isArray(profil?.vocabularyList) ? profil.vocabularyList : [];
+		return vocabularyList.filter((entry) => typeof entry?.question === 'string' && typeof entry?.answer === 'string');
+	}
+
+	public reloadEntries(): void {
+		this.entries = this.getEntries();
+		if (this.currentIndex >= this.entries.length) {
+			this.currentIndex = 0;
+		}
+	}
+
+	public getCurrentEntry(): VocabularyEntry | null {
+		if (this.entries.length === 0) {
+			return null;
+		}
+		return this.entries[this.currentIndex];
+	}
+
+	public nextEntry(): void {
+		if (this.entries.length === 0) {
+			return;
+		}
+		this.currentIndex = (this.currentIndex + 1) % this.entries.length;
+	}
+}

--- a/src/components/vokabeln/controller.ts
+++ b/src/components/vokabeln/controller.ts
@@ -11,11 +11,24 @@ export interface VocabularyEntry {
 export class VokabelnController extends AbstractController {
 	private readonly storageService: StorageService = DI.get<StorageService>('StorageService');
 	public entries: VocabularyEntry[];
-	public currentIndex = 0;
+	public currentPosition = 0;
+	private randomizedOrder: number[] = [];
 
 	public constructor() {
 		super();
 		this.entries = this.getEntries();
+		this.randomizedOrder = this.createRandomizedOrder();
+	}
+
+	private createRandomizedOrder(): number[] {
+		const order = Array.from({ length: this.entries.length }, (_, index) => index);
+		for (let i = order.length - 1; i > 0; i--) {
+			const randomIndex = Math.floor(Math.random() * (i + 1));
+			const temp = order[i];
+			order[i] = order[randomIndex];
+			order[randomIndex] = temp;
+		}
+		return order;
 	}
 
 	private getEntries(): VocabularyEntry[] {
@@ -26,22 +39,26 @@ export class VokabelnController extends AbstractController {
 
 	public reloadEntries(): void {
 		this.entries = this.getEntries();
-		if (this.currentIndex >= this.entries.length) {
-			this.currentIndex = 0;
-		}
+		this.currentPosition = 0;
+		this.randomizedOrder = this.createRandomizedOrder();
 	}
 
 	public getCurrentEntry(): VocabularyEntry | null {
 		if (this.entries.length === 0) {
 			return null;
 		}
-		return this.entries[this.currentIndex];
+		const randomIndex = this.randomizedOrder[this.currentPosition] ?? 0;
+		return this.entries[randomIndex];
 	}
 
 	public nextEntry(): void {
 		if (this.entries.length === 0) {
 			return;
 		}
-		this.currentIndex = (this.currentIndex + 1) % this.entries.length;
+		this.currentPosition++;
+		if (this.currentPosition >= this.randomizedOrder.length) {
+			this.currentPosition = 0;
+			this.randomizedOrder = this.createRandomizedOrder();
+		}
 	}
 }

--- a/src/services/storage/service.ts
+++ b/src/services/storage/service.ts
@@ -122,6 +122,7 @@ export class StorageService {
 				operators: ['+', '-', '•', ':'],
 				difficultyMin: 1,
 				difficultyMax: 1,
+				vocabularyList: [],
 			},
 			results: [],
 			watermarks: {


### PR DESCRIPTION
### Motivation
- Eine einfache Vokabeltrainer-Funktion hinzufügen, deren Wortliste pro Profil gepflegt und gespeichert werden kann.
- Vokabeln sollen im Profil hinterlegt werden, damit mehrere Nutzer/Profile eigene Listen nutzen können.
- Die neue Funktion soll nur bei aktivem Profil verfügbar sein und in die bestehende Navigation integriert werden.

### Description
- Neue Komponenten `src/components/vokabeln/component.preact.tsx` und `src/components/vokabeln/controller.ts` hinzugefügt, die eine einfache Karteikarten-UI (Frage anzeigen, Antwort ein-/ausblenden, nächste Vokabel) bereitstellen.
- Profil-UI erweitert: in `src/components/profil/component.preact.tsx` wurde ein `TextArea` für die Wortliste im Format `Frage;Antwort` pro Zeile ergänzt und an `ProfilController` angebunden.
- `ProfilController` (`src/components/profil/controller.ts`) erweitert mit `vocabularyRawText`, Methoden `setVocabularyRawText` und `getVocabularyList` zum Parsen, Validieren und Persistieren der `vocabularyList` im Profil-Datenobjekt.
- Storage-Default und Migration angepasst: `src/services/storage/service.ts` legt nun `vocabularyList: []` in `createDefaultProfileData()` an und stellt so sicher, dass neue Profile eine leere Vokabelliste haben; bestehende Profil-Updates behalten die Vokabelliste bei.
- Navigation und Routing in `src/components/app/component.preact.tsx` ergänzt, sodass der Menüeintrag `#/vokabeln` und die zugehörige Route nur bei aktivem Profil angezeigt werden.

### Testing
- `pnpm run lint:ts` wurde ausgeführt und lief erfolgreich (TypeScript-Check ohne Fehler).
- `pnpm run lint:eslint` wurde ausgeführt und lief erfolgreich (ESLint ohne Fehler).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c7b1714c832f8f6626c4e4762553)